### PR TITLE
docs: added validation examples for all 5 recently added South Asian …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ validate("India", "110001")   # True
 validate("US", "12345-6789")  # True
 ````
 
+## Examples for recently added countries (Indonesia, Bangladesh, Pakistan, Sri Lanka, Nepal)
+```python
+
+# Indonesia (ID)
+validate("ID", "12345")           # **Expected: True** (valid 5-digit code)
+validate("Indonesia", "12345")    # **Expected: True**
+
+# Bangladesh (BD)
+validate("BD", "1205")            # **Expected: True** (valid 4-digit code)
+
+# Pakistan (PK)
+validate("PK", "44000")           # **Expected: True** (valid 5-digit code)
+
+# Sri Lanka (LK)
+validate("LK", "00300")           # **Expected: True** (valid 5-digit code, e.g., Colombo)
+
+# Nepal (NP)
+validate("NP", "44600")           # **Expected: True** (valid 5-digit code, e.g., Kathmandu)
+```
+
 * ✅ Normalize country identifiers
 
 ```python


### PR DESCRIPTION
## 📌 Pull Request

### Description
Updated README.md with usage examples for the five recently added countries from [commit #16]: Indonesia (ID), Bangladesh (BD), Pakistan (PK), Sri Lanka (LK), and Nepal (NP).

Addresses the issue by adding:
- Code snippets showing `validate()` calls (with country codes and full names).
- Highlighted expected outputs (`**Expected: True**`).

### Changes Made
- [ ] Added/Updated postal regex for a new country
- [ ] Improved documentation

### Screenshots
<img width="920" height="412" alt="image" src="https://github.com/user-attachments/assets/ce7155d9-d8ac-4991-a333-7212c3dbd07d" />
<img width="894" height="124" alt="image" src="https://github.com/user-attachments/assets/e6a33d45-5211-4485-87eb-ca3ca36bb263" />
